### PR TITLE
emulator: tests: exclude "programs" from tests.

### DIFF
--- a/google/cloud/bigtable/emulator/CMakeLists.txt
+++ b/google/cloud/bigtable/emulator/CMakeLists.txt
@@ -100,7 +100,4 @@ foreach (fname ${bigtable_emulator_programs})
                 gRPC::grpc
                 protobuf::libprotobuf)
     google_cloud_cpp_add_common_options(${target})
-    if (BUILD_TESTING)
-        add_test(NAME ${target} COMMAND ${target})
-    endif ()
 endforeach ()


### PR DESCRIPTION
"programs" are not tests in general and can be server binaries which
wait forever and cause the entire test suite to hang and/or
timeout.

In particular add_test should only be called for binaries that are
tests, not arbitrary programs.

TESTED=Verified that "make test" no linger tries to run (and therefore
hang on) the emulator binary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/5)
<!-- Reviewable:end -->
