### PR TITLE
emulator tests: Fix bigtable_emulator_range_set_test.

### DIFF
--- a/google/cloud/bigtable/emulator/range_set_test.cc
+++ b/google/cloud/bigtable/emulator/range_set_test.cc
@@ -275,31 +275,31 @@ TEST(StringRangeSet, RangeStartLess) {
 
 TEST(StringRangeSet, RangeEndLess) {
   EXPECT_TRUE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "A", kOpen),
-      StringRangeSet::Range("unimportant", kWhatever, "B", kOpen)));
+      StringRangeSet::Range("A", kWhatever, "A", kOpen),
+      StringRangeSet::Range("A", kWhatever, "B", kOpen)));
   EXPECT_FALSE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "B", kOpen),
-      StringRangeSet::Range("unimportant", kWhatever, "A", kOpen)));
+      StringRangeSet::Range("A", kWhatever, "B", kOpen),
+      StringRangeSet::Range("A", kWhatever, "A", kOpen)));
   EXPECT_FALSE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "A", kOpen),
-      StringRangeSet::Range("unimportant", kWhatever, "A", kOpen)));
+      StringRangeSet::Range("A", kWhatever, "A", kOpen),
+      StringRangeSet::Range("A", kWhatever, "A", kOpen)));
 
   EXPECT_TRUE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "A", kClosed),
-      StringRangeSet::Range("unimportant", kWhatever, "B", kClosed)));
+      StringRangeSet::Range("A", kWhatever, "A", kClosed),
+      StringRangeSet::Range("A", kWhatever, "B", kClosed)));
   EXPECT_FALSE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "B", kClosed),
-      StringRangeSet::Range("unimportant", kWhatever, "A", kClosed)));
+      StringRangeSet::Range("A", kWhatever, "B", kClosed),
+      StringRangeSet::Range("A", kWhatever, "A", kClosed)));
   EXPECT_FALSE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "A", kClosed),
-      StringRangeSet::Range("unimportant", kWhatever, "A", kClosed)));
+      StringRangeSet::Range("A", kWhatever, "A", kClosed),
+      StringRangeSet::Range("A", kWhatever, "A", kClosed)));
 
   EXPECT_FALSE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "A", kClosed),
-      StringRangeSet::Range("unimportant", kWhatever, "A", kOpen)));
+      StringRangeSet::Range("A", kWhatever, "A", kClosed),
+      StringRangeSet::Range("A", kWhatever, "A", kOpen)));
   EXPECT_TRUE(StringRangeSet::Range::EndLess()(
-      StringRangeSet::Range("unimportant", kWhatever, "A", kOpen),
-      StringRangeSet::Range("unimportant", kWhatever, "A", kClosed)));
+      StringRangeSet::Range("A", kWhatever, "A", kOpen),
+      StringRangeSet::Range("A", kWhatever, "A", kClosed)));
 }
 
 TEST(StringRangeSet, BelowStart) {
@@ -322,8 +322,8 @@ TEST(StringRangeSet, BelowStart) {
 }
 
 TEST(StringRangeSet, AboveEnd) {
-  StringRangeSet::Range const open("unimportant", kWhatever, "B", kOpen);
-  StringRangeSet::Range const closed("unimportant", kWhatever, "B", kClosed);
+  StringRangeSet::Range const open("A", kWhatever, "B", kOpen);
+  StringRangeSet::Range const closed("A", kWhatever, "B", kClosed);
   StringRangeSet::Range const infinite(
       "unimportant", kWhatever, StringRangeSet::Range::Infinity{}, kClosed);
 


### PR DESCRIPTION
The tests aborted due to an assertion in the constructor of Range that
enforced the invariant that start <= end for all well-formed
Ranges. However in several tests testing the ends of ranges, start was
passed in as "unimportant" with end being "A" or "B". This violates
the invariant and causes an abort at runtime.
    
Fixes: TBL-62.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/6)
<!-- Reviewable:end -->
