### PR TITLE
emulator: SetCell: Fix the handling of 0 and negative timestamps.

### DIFF
--- a/google/cloud/bigtable/emulator/column_family.cc
+++ b/google/cloud/bigtable/emulator/column_family.cc
@@ -24,11 +24,6 @@ namespace emulator {
 
 absl::optional<std::string> ColumnRow::SetCell(
     std::chrono::milliseconds timestamp, std::string const& value) {
-  if (timestamp <= std::chrono::milliseconds::zero()) {
-    timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch());
-  }
-
   absl::optional<std::string> ret = absl::nullopt;
   auto cell_it = cells_.find(timestamp);
   if (!(cell_it == cells_.end())) {


### PR DESCRIPTION
* If < -1, return an error and fail the entire mutation chain. 
* If -1, substitute the current system timestamp.
* If 0, store as is (i.e. store a 0 timestamp)

Passing unit checking the above also added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/13)
<!-- Reviewable:end -->
