### PR TITLE
emulator: trivial: fix typo in rollback_test.cc

### DIFF
--- a/google/cloud/bigtable/emulator/rollback_test.cc
+++ b/google/cloud/bigtable/emulator/rollback_test.cc
@@ -868,7 +868,6 @@ TEST(TransactionRollback, DeleteFromRowBasicFunction) {
                        .ok());
 }
 
-
 }  // namespace emulator
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/emulator/rollback_test.cc
+++ b/google/cloud/bigtable/emulator/rollback_test.cc
@@ -273,7 +273,7 @@ Status HasRow(std::shared_ptr<google::cloud::bigtable::emulator::Table>& table,
 //
 // Supplied with a timestamp < -1, it should return an error and fail the entire
 // mutation chain.
-TEST(TransactonRollback, ZeroOrNegativeTimestampHandling) {
+TEST(TransactionRollback, ZeroOrNegativeTimestampHandling) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -363,7 +363,7 @@ TEST(TransactonRollback, ZeroOrNegativeTimestampHandling) {
 }
 
 // Does the SetCell mutation work to set a cell to a specific value?
-TEST(TransactonRollback, SetCellBasicFunction) {
+TEST(TransactionRollback, SetCellBasicFunction) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -396,7 +396,7 @@ TEST(TransactonRollback, SetCellBasicFunction) {
 // Test that an old value is correctly restored in a pre-populated
 // cell, when one of a set of SetCell mutations fails after the cell
 // had been updated with a new value.
-TEST(TransactonRollback, TestRestoreValue) {
+TEST(TransactionRollback, TestRestoreValue) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -459,7 +459,7 @@ TEST(TransactonRollback, TestRestoreValue) {
 
 // Test that a new cell introduced in a chain of SetCell mutations is
 // deleted on rollback if a subsequent mutation fails.
-TEST(TransactonRollback, DeleteValue) {
+TEST(TransactionRollback, DeleteValue) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -514,7 +514,7 @@ TEST(TransactonRollback, DeleteValue) {
 // column family name that is not in the table schema) then the column
 // and any of the cells introduced is deleted in the rollback, but
 // that any pre-transaction-attemot data in the row is unaffected.
-TEST(TransactonRollback, DeleteColumn) {
+TEST(TransactionRollback, DeleteColumn) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -563,7 +563,7 @@ TEST(TransactonRollback, DeleteColumn) {
 // Test that a chain of SetCell mutations that initially introduces a
 // new row, but one of which eventually fails, will end with the whole
 // row rolled back.
-TEST(TransactonRollback, DeleteRow) {
+TEST(TransactionRollback, DeleteRow) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -600,7 +600,7 @@ TEST(TransactonRollback, DeleteRow) {
 // Does the DeleteFromfamily mutation work to delete a row from a
 // specific family and does it rows with the same row key in other
 // column families alone?
-TEST(TransactonRollback, DeleteFromFamilyBasicFunction) {
+TEST(TransactionRollback, DeleteFromFamilyBasicFunction) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -649,7 +649,7 @@ TEST(TransactonRollback, DeleteFromFamilyBasicFunction) {
 
 // Test that DeleteFromfamily can be rolled back in case a subsequent
 // mutation fails.
-TEST(TransactonRollback, DeleteFromFamilyRollback) {
+TEST(TransactionRollback, DeleteFromFamilyRollback) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -716,7 +716,7 @@ TEST(TransactonRollback, DeleteFromFamilyRollback) {
 }
 
 // Does DeleteFromColumn basically work?
-TEST(TransactonRollback, DeleteFromColumnBasicFunction) {
+TEST(TransactionRollback, DeleteFromColumnBasicFunction) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -758,7 +758,7 @@ TEST(TransactonRollback, DeleteFromColumnBasicFunction) {
 }
 
 // Does DeleteFromColumn rollback work?
-TEST(TransactonRollback, DeleteFromColumnRollback) {
+TEST(TransactionRollback, DeleteFromColumnRollback) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -817,7 +817,7 @@ TEST(TransactonRollback, DeleteFromColumnRollback) {
 }
 
 // Can we delete a row from all column families?
-TEST(TransactonRollback, DeleteFromRowBasicFunction) {
+TEST(TransactionRollback, DeleteFromRowBasicFunction) {
   ::google::bigtable::admin::v2::Table schema;
   ::google::bigtable::admin::v2::ColumnFamily column_family;
 
@@ -867,6 +867,7 @@ TEST(TransactonRollback, DeleteFromRowBasicFunction) {
                              column_qualifier)
                        .ok());
 }
+
 
 }  // namespace emulator
 }  // namespace bigtable


### PR DESCRIPTION
emulator: trivial: fix typo in rollback_test.cc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/18)
<!-- Reviewable:end -->
