### PR TITLE
fix: Fix several bugs revealed by the bigtable_data_integration_test test.

### DIFF
--- a/google/cloud/bigtable/emulator/server.cc
+++ b/google/cloud/bigtable/emulator/server.cc
@@ -325,6 +325,7 @@ class DefaultEmulatorServer : public EmulatorServer {
         table_service_(cluster_) {
     builder_.AddListeningPort(host + ":" + std::to_string(port),
                               grpc::InsecureServerCredentials(), &bound_port_);
+    builder_.SetMaxReceiveMessageSize(256 * 1024 * 1024);
     builder_.RegisterService(&bt_service_);
     builder_.RegisterService(&table_service_);
     server_ = builder_.BuildAndStart();

--- a/google/cloud/bigtable/emulator/table.cc
+++ b/google/cloud/bigtable/emulator/table.cc
@@ -542,6 +542,10 @@ Status Table::ReadRows(google::bigtable::v2::ReadRowsRequest const& request,
   if (!maybe_stream) {
     return maybe_stream.status();
   }
+
+  std::int64_t rows_count = 0;
+  absl::optional<std::string> current_row_key;
+
   CellStream& stream = *maybe_stream;
   for (; stream; ++stream) {
     std::cout << "Row: " << stream->row_key()
@@ -551,11 +555,25 @@ Status Table::ReadRows(google::bigtable::v2::ReadRowsRequest const& request,
               << " column_value: " << stream->value() << " label: "
               << (stream->HasLabel() ? stream->label() : std::string("unset"))
               << std::endl;
+
+    if (request.rows_limit() > 0) {
+      if (!current_row_key.has_value() ||
+          stream->row_key() != current_row_key.value()) {
+        rows_count++;
+        current_row_key = stream->row_key();
+      }
+
+      if (rows_count > request.rows_limit()) {
+        break;
+      }
+    }
+
     if (!row_streamer.Stream(*stream)) {
       std::cout << "HOW?" << std::endl;
       return AbortedError("Stream closed by the client.", GCP_ERROR_INFO());
     }
   }
+
   if (!row_streamer.Flush(true)) {
     std::cout << "Flush failed?" << std::endl;
     return AbortedError("Stream closed by the client.", GCP_ERROR_INFO());

--- a/google/cloud/bigtable/emulator/table.cc
+++ b/google/cloud/bigtable/emulator/table.cc
@@ -517,11 +517,15 @@ Table::CheckAndMutateRow(
 Status Table::ReadRows(google::bigtable::v2::ReadRowsRequest const& request,
                        RowStreamer& row_streamer) const {
   std::shared_ptr<StringRangeSet> row_set;
-  if (request.has_rows()) {
+  // We need to check that, not only do we have rows, but that it is
+  // not empty (i.e. at least one of row_range or rows is specified).
+  if (request.has_rows() && (request.rows().row_ranges_size() > 0 ||
+                             request.rows().row_keys_size() > 0)) {
     auto maybe_row_set = CreateStringRangeSet(request.rows());
     if (!maybe_row_set) {
       return maybe_row_set.status();
     }
+
     row_set = std::make_shared<StringRangeSet>(*std::move(maybe_row_set));
   } else {
     row_set = std::make_shared<StringRangeSet>(StringRangeSet::All());


### PR DESCRIPTION
- ReadRows: An empty RowSet should mean stream all the rows, not none of them
- ReadRows: Implement rows_limit
- server.cc: Increase maximum receive message size to 256MiB to accommodate mutations with large row keys (one client test tries to set several large row keys and sends a message that is 128MiB in size).

References: TBL-57
Fixes: TBL-57

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/22)
<!-- Reviewable:end -->
