### PR TITLE
fix: fix segmentation fault due to the use of an invalid grpc server_ object.

### DIFF
--- a/google/cloud/bigtable/emulator/emulator.cc
+++ b/google/cloud/bigtable/emulator/emulator.cc
@@ -33,8 +33,17 @@ int main(int argc, char* argv[]) {
       absl::StrCat("Usage: %s -h <host> -p <port>", argv[0]));
   absl::ParseCommandLine(argc, argv);
 
-  auto server = google::cloud::bigtable::emulator::CreateDefaultEmulatorServer(
-      absl::GetFlag(FLAGS_host), absl::GetFlag(FLAGS_port));
+  auto maybe_server =
+      google::cloud::bigtable::emulator::CreateDefaultEmulatorServer(
+          absl::GetFlag(FLAGS_host), absl::GetFlag(FLAGS_port));
+  if (!maybe_server) {
+    std::cerr << "CreateDefaultEmulatorServer() failed. See other logging for "
+                 "possible reason"
+              << std::endl;
+    std::exit(1);
+  }
+
+  auto& server = maybe_server.value();
 
   std::cout << "Server running on port " << server->bound_port() << "\n";
   server->Wait();

--- a/google/cloud/bigtable/emulator/emulator.cc
+++ b/google/cloud/bigtable/emulator/emulator.cc
@@ -37,10 +37,10 @@ int main(int argc, char* argv[]) {
       google::cloud::bigtable::emulator::CreateDefaultEmulatorServer(
           absl::GetFlag(FLAGS_host), absl::GetFlag(FLAGS_port));
   if (!maybe_server) {
-    std::cerr << "CreateDefaultEmulatorServer() failed. See other logging for "
+    std::cerr << "CreateDefaultEmulatorServer() failed. See logs for "
                  "possible reason"
               << std::endl;
-    std::exit(1);
+    return 1;
   }
 
   auto& server = maybe_server.value();

--- a/google/cloud/bigtable/emulator/server.h
+++ b/google/cloud/bigtable/emulator/server.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_EMULATOR_SERVER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_EMULATOR_SERVER_H
 
+#include "google/cloud/status_or.h"
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -36,7 +37,7 @@ class EmulatorServer {
   virtual void Wait() = 0;
 };
 
-std::unique_ptr<EmulatorServer> CreateDefaultEmulatorServer(
+StatusOr<std::unique_ptr<EmulatorServer>> CreateDefaultEmulatorServer(
     std::string const& host, std::uint16_t port);
 
 }  // namespace emulator

--- a/google/cloud/bigtable/emulator/server_test.cc
+++ b/google/cloud/bigtable/emulator/server_test.cc
@@ -21,6 +21,7 @@
 #include <google/bigtable/v2/bigtable.pb.h>
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
+#include <gtest/gtest.h>
 
 namespace google {
 namespace cloud {
@@ -216,6 +217,12 @@ TEST_F(ServerTest, TableAdminUpdateTable) {
   grpc::Status status =
       TableAdminClient()->UpdateTable(&ctx_, request, &response);
   EXPECT_NE(status.error_code(), grpc::StatusCode::UNIMPLEMENTED);
+}
+
+// Test that the failure path for server creation does not crash.
+TEST(ServerCreationTest, TestServerCreationFailurePath) {
+  auto maybe_server = CreateDefaultEmulatorServer("invalid_host_address", 0);
+  ASSERT_EQ(false, maybe_server.ok());
 }
 
 }  // namespace emulator

--- a/google/cloud/bigtable/emulator/server_test.cc
+++ b/google/cloud/bigtable/emulator/server_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/emulator/server.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <google/bigtable/admin/v2/bigtable_table_admin.pb.h>
 #include <google/bigtable/admin/v2/table.pb.h>
@@ -33,7 +34,9 @@ class ServerTest : public ::testing::Test {
   grpc::ClientContext ctx_;
 
   void SetUp() override {
-    server_ = CreateDefaultEmulatorServer("127.0.0.1", 0);
+    auto maybe_server = CreateDefaultEmulatorServer("127.0.0.1", 0);
+    ASSERT_STATUS_OK(maybe_server);
+    server_ = std::move(maybe_server.value());
     channel_ = grpc::CreateChannel(
         "localhost:" + std::to_string(server_->bound_port()),
         grpc::InsecureChannelCredentials());


### PR DESCRIPTION
BuildAndStart() can fail for any number of reasons (e.g. when passed a port reserved for privileged use or a non-existent local address). We were not checking for this and would try to use the server unconditionally, causing a segmentation fault (e.g. when emulator was called by a non-root user as: ./emulator -p 100).

This adds a fix so that we can check that we have a valid server object before trying to use it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/24)
<!-- Reviewable:end -->
