### PR TITLE
feat: bigtable emulator: Use new emulator (written in C++) for tests.

### DIFF
--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -41,6 +41,12 @@ fi
 CBT_INSTANCE_ADMIN_EMULATOR_START=(
   "${BINARY_DIR}/google/cloud/bigtable/tests/instance_admin_emulator"
 )
+
+# Configure run_emulators_utils.sh to find the cbt emulator.
+CBT_EMULATOR_CMD=(
+  "${BINARY_DIR}/google/cloud/bigtable/emulator/emulator"
+)
+
 source module /google/cloud/bigtable/tools/run_emulator_utils.sh
 
 cd "${BINARY_DIR}"

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -92,7 +92,6 @@ function start_emulators() {
   io::log "Launching Cloud Bigtable emulators in the background"
   trap kill_emulators EXIT
 
-  local -r CBT_EMULATOR_CMD="/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator"
   "${CBT_EMULATOR_CMD}" -port "${emulator_port}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
 


### PR DESCRIPTION
This swaps out the old emulator for the new one for tests.

TESTED=I have tested this on my machine (running the Bigtable test suite) and it now starts and tests against our emulator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/25)
<!-- Reviewable:end -->
