### PR TITLE
fix: fix MSVC compilation error due to storing a int64_t in a size_t

### DIFF
--- a/google/cloud/bigtable/emulator/filter.cc
+++ b/google/cloud/bigtable/emulator/filter.cc
@@ -919,7 +919,7 @@ StatusOr<CellStreamConstructor> CreateFilterImpl(
     return res;
   }
   if (filter.has_cells_per_column_limit_filter()) {
-    std::int64_t cells_per_column_limit =
+    std::int32_t cells_per_column_limit =
         filter.cells_per_column_limit_filter();
     if (cells_per_column_limit < 0) {
       return InvalidArgumentError(


### PR DESCRIPTION
The compiler spits out an error in pedantic mode ([link](https://github.com/googleapis/google-cloud-cpp/actions/runs/16149454809/job/45577395445#step:12:3249)) because on 32 bit platforms, there is a usually the possibility of an overflow. However, the quantity is guaranteed to be 32 bit (https://github.com/googleapis/googleapis/blob/74657e8a6690b249c048f685124ee3b8473b70b4/google/bigtable/v2/data.proto#L497) so use int32_t to store it and fix the MSVC compiler warning and failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/29)
<!-- Reviewable:end -->
