### PR TITLE
fix: MSVC (windows): Prevent GetCurrentTime macro expansion in windows.

### DIFF
--- a/google/cloud/bigtable/emulator/server.cc
+++ b/google/cloud/bigtable/emulator/server.cc
@@ -245,9 +245,9 @@ class EmulatorTableService final : public btadmin::BigtableTableAdmin::Service {
     btadmin::UpdateTableMetadata res_md;
     res_md.set_name(request->table().name());
     *res_md.mutable_start_time() =
-        google::protobuf::util::TimeUtil::GetCurrentTime();
+        (google::protobuf::util::TimeUtil::GetCurrentTime)();
     *res_md.mutable_end_time() =
-        google::protobuf::util::TimeUtil::GetCurrentTime();
+        (google::protobuf::util::TimeUtil::GetCurrentTime)();
     response->set_name("UpdateTable");
     response->mutable_metadata()->PackFrom(std::move(res_md));
     response->set_done(true);


### PR DESCRIPTION
Without this, GetCurrentTime which exists as a macro in Windows is expanded, leading to this compilation error:
https://github.com/googleapis/google-cloud-cpp/actions/runs/16149454809/job/45577395445#step:12:3259

This method of fixing this problem is documented and recommended here: https://protobuf.dev/support/migration/#getcurrenttime

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/30)
<!-- Reviewable:end -->
