### PR TITLE
fix: windows build: fix windows buiuld.

### DIFF
--- a/google/cloud/bigtable/emulator/CMakeLists.txt
+++ b/google/cloud/bigtable/emulator/CMakeLists.txt
@@ -21,7 +21,6 @@ add_library(
     cluster.h
     column_family.cc
     column_family.h
-    column_family_test.cc
     filter.cc
     filter.h
     filtered_map.h

--- a/google/cloud/bigtable/emulator/bigtable_emulator_common.bzl
+++ b/google/cloud/bigtable/emulator/bigtable_emulator_common.bzl
@@ -33,7 +33,6 @@ bigtable_emulator_common_hdrs = [
 bigtable_emulator_common_srcs = [
     "cluster.cc",
     "column_family.cc",
-    "column_family_test.cc",
     "filter.cc",
     "range_set.cc",
     "row_streamer.cc",

--- a/google/cloud/bigtable/emulator/row_streamer.cc
+++ b/google/cloud/bigtable/emulator/row_streamer.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/bigtable/emulator/cell_view.h"
 #include <google/bigtable/v2/bigtable.pb.h>
 #include <absl/types/optional.h>
-#include <grpcpp/support/sync_stream.h>
 #include <chrono>
 #include <utility>
 

--- a/google/cloud/bigtable/emulator/row_streamer.h
+++ b/google/cloud/bigtable/emulator/row_streamer.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/bigtable/emulator/cell_view.h"
 #include "absl/types/optional.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <google/bigtable/v2/bigtable.pb.h>
+#include <grpcpp/server.h>
 #include <grpcpp/support/sync_stream.h>
 #include <string>
 #include <vector>

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -204,7 +204,6 @@ google_cloud_cpp_bigtable_srcs = [
     "internal/prefix_range_end.cc",
     "internal/rate_limiter.cc",
     "internal/readrowsparser.cc",
-    "internal/retry_context.cc",
     "internal/row_range_helpers.cc",
     "internal/traced_row_reader.cc",
     "metadata_update_policy.cc",


### PR DESCRIPTION
The failures of the build were due to:

- Missing includes leading to errors in template type instantiation
- column_family_test.cc was included in the common library causing duplicate definitions at link time.

Not sure why these problems did not manifest on Linux which builds and test cleanly before this change, even with -pedantic and -pedantic-errors turned on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/google-cloud-cpp/33)
<!-- Reviewable:end -->
